### PR TITLE
Add basic config for Flexispot E6

### DIFF
--- a/packages/esphome/flexispot_e6.yaml
+++ b/packages/esphome/flexispot_e6.yaml
@@ -1,6 +1,6 @@
 substitutions:
   device_name: Flexispot E6
-  name: flexispot_e5b
+  name: flexispot_e6
   min_height: "60.1" # Min height + 0.1
   max_height: "122.9" # Max height - 0.1
   


### PR DESCRIPTION
This adds a basic configuration for Flexispot model E6. I own this desk myself and I have tested that it's basic pinout (TX, RX, GND, +5V, PIN 20) coincides with the pinout of E5B.
