### PR TITLE
publish esphome+ardiuno to platform.io

### DIFF
--- a/.github/semver.yaml
+++ b/.github/semver.yaml
@@ -1,0 +1,20 @@
+version: 1
+force:
+  major: 1
+  existing: true
+wording:
+  patch:
+    - bump
+    - update
+    - initial
+    - tweak
+  minor:
+    - change
+    - improve
+    - implement
+    - fix
+  major:
+    - breaking
+  release:
+    - release-candidate
+    - add-rc

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,7 @@ jobs:
     name: Arduino Publish
     needs: [semver]
     runs-on: ubuntu-latest
+    environment: platformio_publish
     strategy:
       matrix:
         package: 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,61 @@
+name: Publisher
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  semver:
+    name: Generate semantic version number
+    outputs:
+      semantic_version: ${{ steps.semver.outputs.semantic_version }}
+    runs-on: ubuntu-latest
+    steps:  
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - id: semver
+        uses: lukaszraczylo/semver-generator@1.4.18
+        with:
+          config_file: .github/semver.yaml
+          repository_local: true
+      - uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{ steps.semver.outputs.semantic_version}}
+          prerelease: false
+          title: ${{ steps.semver.outputs.semantic_version}}
+          files: "*"
+
+  arduino:
+    name: Arduino Publish
+    needs: [semver]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: 
+          - arduino
+          - esphome
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install platformio==6.1.5
+      - name: Bump version in manifest
+        run: cat <<< $(jq ".version = \"${SEMVER}\"" library.json ) > library.json
+        working-directory: packages/${{ matrix.package }}
+        env:
+          SEMVER: ${{ needs.semver.outputs.semantic_version}}
+      - run: cat library.json
+        working-directory: packages/${{ matrix.package }}
+      - run: pio package publish --non-interactive --no-notify
+        working-directory: packages/${{ matrix.package }}
+        env:
+          PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_TOKEN }}
+
+  # python:
+  #   name: Pypi Publish
+  #   needs: [semver]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-python@v4

--- a/packages/arduino/library.json
+++ b/packages/arduino/library.json
@@ -1,0 +1,27 @@
+{
+  "name": "LoctekMotion_IoT_arduino",
+  "version": "1.0.0",
+  "description": "Turn your LoctekMotion/FlexiSpot desk into a smart desk",
+  "keywords": "esp8266, esp32, home-assistant, smart-desk, standing-desk, flexispot, loctek, loctekmotion, flexispot-desks",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iMicknl/LoctekMotion_IoT.git"
+  },
+  "authors": [
+    {
+      "name": "Mick Vleeshouwer",
+      "email": "mick@imick.nl",
+      "url": "https://www.imick.nl",
+      "maintainer": true
+    },
+    {
+      "name": "Chris Nesbitt-Smith",
+      "email": "chris@cns.me.uk",
+      "url": "https://cns.me",
+      "maintainer": false
+    }
+  ],
+  "license": "MIT",
+  "frameworks": "*",
+  "platforms": "*"
+}

--- a/packages/esphome/library.json
+++ b/packages/esphome/library.json
@@ -1,0 +1,27 @@
+{
+  "name": "LoctekMotion_IoT_esphome",
+  "version": "1.0.0",
+  "description": "Turn your LoctekMotion/FlexiSpot desk into a smart desk",
+  "keywords": "esp8266, esp32, home-assistant, smart-desk, standing-desk, flexispot, loctek, loctekmotion, flexispot-desks",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iMicknl/LoctekMotion_IoT.git"
+  },
+  "authors": [
+    {
+      "name": "Mick Vleeshouwer",
+      "email": "mick@imick.nl",
+      "url": "https://www.imick.nl",
+      "maintainer": true
+    },
+    {
+      "name": "Chris Nesbitt-Smith",
+      "email": "chris@cns.me.uk",
+      "url": "https://cns.me",
+      "maintainer": false
+    }
+  ],
+  "license": "MIT",
+  "frameworks": "*",
+  "platforms": "*"
+}


### PR DESCRIPTION
Publishes the code to platform.io
# Note to maintainers:
Before merging this you'll need to:[create an environment](https://github.com/iMicknl/LoctekMotion_IoT/settings/environments/new) named `platformio_publish`
and create a secret within that environment `PLATFORMIO_TOKEN` secret in github

the contents of that secret you can get from:
```bash
pio account register # if you don't already have an account
# verify the email
pio account login
pio account token
```

After this being merged, I'll update the yaml to reflect pulling in the library from the platform.io registry, and I'll also unpublish where its currently being published to:

 - https://registry.platformio.org/libraries/chrisns/LoctekMotion_IoT_esphome
 - https://registry.platformio.org/libraries/chrisns/LoctekMotion_IoT_arduino

would also be good to publish the raspi to pypi which I'd be happy to work on too if you like