### PR TITLE
msg_length changed on newer controllers (10 instead of 7)

### DIFF
--- a/packages/esphome/desk_height_sensor.h
+++ b/packages/esphome/desk_height_sensor.h
@@ -108,7 +108,7 @@ public:
       if (history[2] == 0x9b)
       {
 
-        if (msg_type == 0x12 && msg_len == 7)
+        if (msg_type == 0x12 && (msg_len == 7 || msg_len == 10))
         {
           // Empty height
           if (incomingByte == 0)


### PR DESCRIPTION
Some newer controllers (such as CB38M4A(IB)-1 (flexispot e7q) report their heigt with a msg_lenght of 10 instead of 7. This should be reverse-compatible, even though i have not tested that.