### PR TITLE
Update flexispot_e5b_esp32.yaml

### DIFF
--- a/packages/esphome/flexispot_e5b_esp32.yaml
+++ b/packages/esphome/flexispot_e5b_esp32.yaml
@@ -165,7 +165,7 @@ switch:
     icon: mdi:key
     id: "keypad_switch"
     internal: false
-    restore_state: true
+    restore_mode: RESTORE_DEFAULT_OFF
     assumed_state: false
     optimistic: true
 


### PR DESCRIPTION
restore_state was deprecated in 2023.07 ESPHome release

https://esphome.io/changelog/2023.7.0.html?highlight=restore_state