### PR TITLE
set `platform: esphome` in ota

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you don't have an extra RJ45 port on your desk controller, you will need to u
 
 ## Pin-out
 | RJ45 pin | Name      |  ESP32 |
-| -------- | --------- | --------- | 
+| -------- | --------- | --------- |
 | 8        | +5V (VDD) |  VIN |
 | 7        | GND       | GND |
 | 6        | TX        | TX2 (GPIO17) |

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -42,6 +42,7 @@ api:
     key: ${encryption_key}
 
 ota:
+  platform: esphome
 
 wifi:
   ssid: ${ssid}


### PR DESCRIPTION
otherwise the following error occurs using ESPHome 2024.12.2:

```
At least one platform must be specified for 'ota'; add 'platform: esphome' for original OTA functionality
```