### PR TITLE
Potential solution to overshooting send empty command to stop desk

### DIFF
--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -77,9 +77,11 @@ sensor:
     - below: ${min_height}
       then:
         - switch.turn_off: switch_down
+        - button.press: button_wake_screen
     - above: ${max_height}
       then:
         - switch.turn_off: switch_up
+        - button.press: button_wake_screen
     on_value:
       then:
         - cover.template.publish:
@@ -236,6 +238,7 @@ cover:
     stop_action:
       - switch.turn_off: switch_up
       - switch.turn_off: switch_down
+      - button.press: button_wake_screen
     open_action:
       - switch.turn_off: switch_down
       - switch.turn_on: switch_up


### PR DESCRIPTION
Potentially a solution to the overshoot issue. Needs testing on more desks but this better matches the behaviour of my keypad - when pressing a button the respective UART message is sent repeatedly until released when the 'empty' command is sent (called Virtual Screen in office-desk-esp32.yaml). 

This seems to very quickly stop the movement of the desk. Thus, the changing the cover and setting the template number behave much more responsively.

Additionally I have also found that disabling the logger reduces lag on inputs under some circumstances. It seems to get 'overwhelmed' with messages but I also have other components on the same micro so may not be universal.

Tested on Flexispot EC5