### PR TITLE
Improve configuration for desk that use "inch"

### DIFF
--- a/packages/office-desk-esp32-passthrough.yaml
+++ b/packages/office-desk-esp32-passthrough.yaml
@@ -4,14 +4,14 @@ substitutions:
   unit_of_measurement: "cm" # or "in"
   min_height: "73.5"
   max_height: "123"
-  ssid: "your_wifi_ssid"
-  wifi_password: "your_wifi_password"
-  ap_fallback_password: "CHANGE_ME"
+  ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  ap_fallback_password: !secret ap_fallback_password
   tx_pin: GPIO17 # TXD 2
   rx_pin: GPIO16 # RXD 2
   rx_pin_keypad: GPIO3 # RX 0
   screen_pin: GPIO23
-  encryption_key: "iOZqtvw31Yy6sasRl5h2DElG2VDlqW2WjJEKObVN8bg=" # CHANGE_ME
+  encryption_key: !secret encryption_key
 
 external_components:
   source: github://iMicknl/LoctekMotion_IoT

--- a/packages/office-desk-esp32-passthrough.yaml
+++ b/packages/office-desk-esp32-passthrough.yaml
@@ -11,7 +11,7 @@ substitutions:
   rx_pin: GPIO16 # RXD 2
   rx_pin_keypad: GPIO3 # RX 0
   screen_pin: GPIO23
-  encryption_key: "CHANGE_ME"
+  encryption_key: "iOZqtvw31Yy6sasRl5h2DElG2VDlqW2WjJEKObVN8bg=" # CHANGE_ME
 
 external_components:
   source: github://iMicknl/LoctekMotion_IoT

--- a/packages/office-desk-esp32-passthrough.yaml
+++ b/packages/office-desk-esp32-passthrough.yaml
@@ -1,16 +1,17 @@
 substitutions:
   device_name: Flexispot desk
   name: office-desk-flexispot
-  min_height: "73.5" # cm
-  max_height: "123" # cm
+  unit_of_measurement: "cm" # or "in"
+  min_height: "73.5"
+  max_height: "123" 
   ssid: "your_wifi_ssid"
   wifi_password: "your_wifi_password"
-  ap_fallback_password: "MnANX95MWad1"
+  ap_fallback_password: "CHANGE_ME"
   tx_pin: GPIO17 # TXD 2
   rx_pin: GPIO16 # RXD 2
   rx_pin_keypad: GPIO3 # RX 0
   screen_pin: GPIO23
-  encryption_key: "iOZqtvw31Yy6sasRl5h2DElG2VDlqW2WjJEKObVN8bg="
+  encryption_key: "CHANGE_ME"
 
 external_components:
   source: github://iMicknl/LoctekMotion_IoT
@@ -80,6 +81,7 @@ sensor:
   - platform: loctekmotion_desk_height
     id: "desk_height"
     name: Desk height
+    unit_of_measurement: ${unit_of_measurement}
     uart_id: desk_uart
     on_value_range:
     - below: ${min_height}
@@ -321,7 +323,7 @@ number:
     min_value: ${min_height}
     max_value: ${max_height}
     icon: "mdi:counter"
-    unit_of_measurement: "cm"
+    unit_of_measurement: ${unit_of_measurement}
     device_class: "distance"
     step: 0.1
     lambda: !lambda |-

--- a/packages/office-desk-esp32-passthrough.yaml
+++ b/packages/office-desk-esp32-passthrough.yaml
@@ -3,7 +3,7 @@ substitutions:
   name: office-desk-flexispot
   unit_of_measurement: "cm" # or "in"
   min_height: "73.5"
-  max_height: "123" 
+  max_height: "123"
   ssid: "your_wifi_ssid"
   wifi_password: "your_wifi_password"
   ap_fallback_password: "CHANGE_ME"

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -4,13 +4,13 @@ substitutions:
   unit_of_measurement: "cm" # or "in"
   min_height: "73.5"
   max_height: "123"
-  ssid: "your_wifi_ssid"
-  wifi_password: "your_wifi_password"
-  ap_fallback_password: "CHANGE_ME"
+  ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  ap_fallback_password: !secret ap_fallback_password
   tx_pin: GPIO17 # TXD 2
   rx_pin: GPIO16 # RXD 2
   screen_pin: GPIO23
-  encryption_key: "iOZqtvw31Yy6sasRl5h2DElG2VDlqW2WjJEKObVN8bg=" # CHANGE_ME
+  encryption_key: !secret encryption_key
 
 external_components:
   source: github://iMicknl/LoctekMotion_IoT

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -1,15 +1,16 @@
 substitutions:
   device_name: Flexispot desk
   name: office-desk-flexispot
-  min_height: "73.5" # cm
-  max_height: "123" # cm
+  unit_of_measurement: "cm" # or "in"
+  min_height: "73.5"
+  max_height: "123" 
   ssid: "your_wifi_ssid"
   wifi_password: "your_wifi_password"
-  ap_fallback_password: "MnANX95MWad1"
+  ap_fallback_password: "CHANGE_ME"
   tx_pin: GPIO17 # TXD 2
   rx_pin: GPIO16 # RXD 2
   screen_pin: GPIO23
-  encryption_key: "iOZqtvw31Yy6sasRl5h2DElG2VDlqW2WjJEKObVN8bg="
+  encryption_key: "CHANGE_ME"
 
 external_components:
   source: github://iMicknl/LoctekMotion_IoT
@@ -75,6 +76,7 @@ sensor:
   - platform: loctekmotion_desk_height
     id: "desk_height"
     name: Desk height
+    unit_of_measurement: ${unit_of_measurement}
     on_value_range:
     - below: ${min_height}
       then:
@@ -270,7 +272,7 @@ number:
     min_value: ${min_height}
     max_value: ${max_height}
     icon: "mdi:counter"
-    unit_of_measurement: "cm"
+    unit_of_measurement: ${unit_of_measurement}
     device_class: "distance"
     step: 0.1
     lambda: !lambda |-

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -10,7 +10,7 @@ substitutions:
   tx_pin: GPIO17 # TXD 2
   rx_pin: GPIO16 # RXD 2
   screen_pin: GPIO23
-  encryption_key: "CHANGE_ME"
+  encryption_key: "iOZqtvw31Yy6sasRl5h2DElG2VDlqW2WjJEKObVN8bg=" # CHANGE_ME
 
 external_components:
   source: github://iMicknl/LoctekMotion_IoT

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -3,7 +3,7 @@ substitutions:
   name: office-desk-flexispot
   unit_of_measurement: "cm" # or "in"
   min_height: "73.5"
-  max_height: "123" 
+  max_height: "123"
   ssid: "your_wifi_ssid"
   wifi_password: "your_wifi_password"
   ap_fallback_password: "CHANGE_ME"

--- a/packages/secrets.yaml
+++ b/packages/secrets.yaml
@@ -1,0 +1,4 @@
+wifi_ssid: "MyWifiNetwork"
+wifi_password: "MyWifiPassword"
+ap_fallback_password: "MyFallbackPassword"
+encryption_key: "Y2hhbmdlX21l" # Change this to a secure base64-encoded 32-byte key, e.g. generated with `openssl rand -base64 32`

--- a/packages/secrets.yaml
+++ b/packages/secrets.yaml
@@ -1,4 +1,4 @@
 wifi_ssid: "MyWifiNetwork"
 wifi_password: "MyWifiPassword"
 ap_fallback_password: "MyFallbackPassword"
-encryption_key: "Y2hhbmdlX21l" # Change this to a secure base64-encoded 32-byte key, e.g. generated with `openssl rand -base64 32`
+encryption_key: "rUW7Qc1tJIoXa1jtYVjv4w6FS56fLoEPvzIZw6WNw3s=" # Change this to a secure base64-encoded 32-byte key, e.g. generated with `openssl rand -base64 32`


### PR DESCRIPTION
- Add unit selection as a substitution option to easily switch between inches and centimeters
- Remove the `ap_fallback_password` and `encryption_key` values
- Add unit of measurement to the height sensor