### PR TITLE
Change framework type from Arduino to ESP-IDF

### DIFF
--- a/packages/office-desk-esp32-passthrough.yaml
+++ b/packages/office-desk-esp32-passthrough.yaml
@@ -20,7 +20,7 @@ external_components:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 esphome:
   name: ${name}

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -19,7 +19,7 @@ external_components:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 esphome:
   name: ${name}

--- a/tests/office-desk-esp32-passthrough.yaml
+++ b/tests/office-desk-esp32-passthrough.yaml
@@ -19,7 +19,7 @@ external_components:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 esphome:
   name: ${name}

--- a/tests/office-desk-esp32.yaml
+++ b/tests/office-desk-esp32.yaml
@@ -19,7 +19,7 @@ external_components:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 esphome:
   name: ${name}


### PR DESCRIPTION
If we change the framework to esp-idf, this will also work with ESP32-C6 chips, as ESPHome does not allow arduino on ESP-C6 and everything still compiles just fine.