### PR TITLE
Add polling mode select and interval logic to fetch desk height

### DIFF
--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -294,3 +294,47 @@ number:
                 lambda: |-
                   return id(desk_height).state <= x;
             - cover.stop: desk_cover
+
+select:
+  - platform: template
+    name: "Polling mode"
+    id: polling_mode
+    icon: mdi:timer-cog
+    entity_category: "config"
+    optimistic: true
+    restore_value: false # always starts back on "Normal (10s)" after any restart
+    initial_option: "Normal (10s)"
+    options:
+      - "Off"
+      - "Normal (10s)"
+      - "Greedy (5s)"
+    on_value:
+      then:
+        - if:
+            condition:
+              not:
+                - select.is:
+                    id: polling_mode
+                    options: ["Off"]
+            then:
+              - button.press: button_m
+
+interval:
+  - interval: 5s
+    then:
+      - if:
+          condition:
+            select.is:
+              id: polling_mode
+              options: ["Greedy (5s)"]
+          then:
+            - button.press: button_wake_screen
+  - interval: 10s
+    then:
+      - if:
+          condition:
+            select.is:
+              id: polling_mode
+              options: ["Normal (10s)"]
+          then:
+            - button.press: button_wake_screen

--- a/packages/office-desk-esp32.yaml
+++ b/packages/office-desk-esp32.yaml
@@ -302,7 +302,7 @@ select:
     icon: mdi:timer-cog
     entity_category: "config"
     optimistic: true
-    restore_value: false # always starts back on "Normal (10s)" after any restart
+    restore_value: true # preserve the last selected polling mode across restarts
     initial_option: "Normal (10s)"
     options:
       - "Off"


### PR DESCRIPTION
This would create a fix/workaround for #123.

This will fetch the desk height every 10 seconds with the option to set it to 5s or to disable this feature.

Also while turning it to 10 or 5 seconds after being off, reinitiate a button M press to get the current value