### PR TITLE
Add Flexispot E1L: accessory-port protocol notes + ESPHome package

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ In order to connect the control box to a Raspberry Pi and ESP32/ESP8266 chip I u
     <td align="center"><a href="#hs13b-1"><br /><sub><b>HS13B-1</b></sub></a></td>
     <td align="center"><a href="#hs13a-1"><br /><sub><b>HS13A-1</b></sub></a></td>
     <td align="center"><a href="#hs01b-1"><br /><sub><b>HS01B-1</b></sub></a></td>
+    <td align="center"><a href="#flexispot-e1l-unmarked-touch-panel"><br /><sub><b>E1L (unmarked)</b></sub></a></td>
   </tr>
 </table>
 <!-- markdownlint-enable -->
@@ -196,6 +197,45 @@ So the custom controller also uses RX to receive data and TX to send data.
 
 Note that RX and TX is defined like this on receiver (control panel) side.
 So the custom controller also uses RX to receive data and TX to send data.
+
+#### Flexispot E1L (unmarked touch panel)
+
+- **Desk model**: Flexispot E1L (L-shaped, 2 motors)
+- **Tested with control box**: CB38M2J(IB)-1 (same model as the Flexispot E7)
+- **Control panel**: no model number printed anywhere; curved touch panel with LED display and Up / Down / 1 / 2 / 3 / M / A keys
+- **Source**: empirical UART sniffing (2026), see behavior notes below
+
+The pinout is identical to [HS13B-1](#hs13b-1). The desk was integrated via the
+control box's **second (top) RJ45 jack** while the control panel stayed
+connected to the bottom jack. Both the standard command set and the height
+frames work — but this accessory port behaves differently than the primary
+port in a few important ways:
+
+**Behavior notes (accessory port):**
+
+- The two RJ45 jacks are **not parallel taps**: the accessory port never sees
+  the control panel's traffic, only frames the control box itself sends.
+- Commands are only accepted after `PIN 20` has been HIGH for **~1 second**
+  (matches the physical panel's UX, where the first key press only wakes the
+  display and the second one acts).
+- The control box **only reports height in response to a received command**
+  (including the harmless Wake Up / "no keys" frame `9b 06 02 00 00 6c a1 9d`).
+  It does **not** broadcast during autonomous preset travel — to track a
+  preset move, keep sending Wake Up ~once per second while the desk travels.
+- While awake, the control box streams a **~5 Hz heartbeat**
+  `9b 04 11 7c c3 9d` on the accessory port, stopping a few seconds after it
+  goes back to sleep. A heartbeat session that your controller did not
+  initiate means the desk was adjusted via the physical panel — useful as a
+  trigger to re-poll the height afterwards.
+- Two further frames were observed and safely ignored: `9b 04 15 bf c2 9d`
+  (appears around command handling) and `9b 04 81 10 c3 9d` (meaning unknown).
+- Checksum note: all frames verify as **CRC16-Modbus** computed over the
+  bytes from `length` through the end of `payload`, transmitted high byte
+  first — this matches the checksums in the command list below and lets you
+  construct arbitrary frames.
+
+See [`packages/flexispot-e1l-esp32.yaml`](packages/flexispot-e1l-esp32.yaml)
+for a complete ESPHome package implementing all of the above.
 
 Other control panels / control boxes could be supported in the same way, but you would need to figure the RJ45 pinout mapping. Most control boxes have an extra RJ45 port for serial communication, but otherwise you would need to place your device in between the control panel and the control box.
 

--- a/README.md
+++ b/README.md
@@ -215,9 +215,11 @@ port in a few important ways:
 
 - The two RJ45 jacks are **not parallel taps**: the accessory port never sees
   the control panel's traffic, only frames the control box itself sends.
-- Commands are only accepted after `PIN 20` has been HIGH for **~1 second**
-  (matches the physical panel's UX, where the first key press only wakes the
-  display and the second one acts).
+- Wakefulness is **global**: the box accepts accessory-port commands whenever
+  it is awake, regardless of which port woke it. From cold, `PIN 20` must be
+  HIGH for **~1 second** before a command registers (matches the physical
+  panel's UX, where the first key press only wakes the display and the second
+  one acts).
 - The control box **only reports height in response to a received command**
   (including the harmless Wake Up / "no keys" frame `9b 06 02 00 00 6c a1 9d`).
   It does **not** broadcast during autonomous preset travel — to track a
@@ -225,8 +227,10 @@ port in a few important ways:
 - While awake, the control box streams a **~5 Hz heartbeat**
   `9b 04 11 7c c3 9d` on the accessory port, stopping a few seconds after it
   goes back to sleep. A heartbeat session that your controller did not
-  initiate means the desk was adjusted via the physical panel — useful as a
-  trigger to re-poll the height afterwards.
+  initiate means the desk is being adjusted via the physical panel — and
+  since wakefulness is global, you can poll with Wake Up frames **during**
+  that session for live height tracking of panel-driven moves (verified not
+  to interfere with physically held buttons).
 - Two further frames were observed and safely ignored: `9b 04 15 bf c2 9d`
   (appears around command handling) and `9b 04 81 10 c3 9d` (meaning unknown).
 - Checksum note: all frames verify as **CRC16-Modbus** computed over the

--- a/packages/flexispot-e1l-esp32.yaml
+++ b/packages/flexispot-e1l-esp32.yaml
@@ -1,0 +1,199 @@
+# Flexispot E1L (control box CB38M2J(IB)-1, accessory RJ45 port) — ESP32
+#
+# Plug the ESP32 into the control box's FREE second RJ45 jack; the physical
+# control panel stays in the other one. Pinout = HS13B-1 (see README).
+#
+#   RJ45 pin 8 -> +5V (powers the ESP32 via VIN)
+#   RJ45 pin 7 -> GND
+#   RJ45 pin 5 -> ${rx_pin}  (control box -> ESP: heartbeat + height frames)
+#   RJ45 pin 6 -> ${tx_pin}  (ESP -> control box: commands)
+#   RJ45 pin 4 -> ${screen_pin}  (PIN 20 wake line)
+#
+# E1L accessory-port quirks handled by this package (see README section
+# "Flexispot E1L" for details):
+#   - PIN 20 must be HIGH ~1s before a command is accepted -> every button
+#     wakes first, then sends.
+#   - The box only reports height in response to a command -> preset buttons
+#     poll with Wake Up frames during the autonomous travel.
+#   - A ~5 Hz heartbeat (9b 04 11) runs while the box is awake -> used to
+#     detect adjustments made on the physical panel and re-poll the height.
+
+substitutions:
+  device_name: flexispot-desk
+  friendly_name: Flexispot Desk
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  screen_pin: GPIO23
+
+esphome:
+  name: ${device_name}
+  friendly_name: ${friendly_name}
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+external_components:
+  - source: github://iMicknl/LoctekMotion_IoT
+    components: [ loctekmotion_desk_height ]
+
+logger:
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+captive_portal:
+
+web_server:
+  port: 80
+  version: 3
+  local: true
+
+globals:
+  # millis() of the last heartbeat frame (9b 04 11) from the control box;
+  # the box streams these at ~5 Hz while awake, silence = asleep.
+  - id: last_hb
+    type: uint32_t
+    initial_value: '0'
+  # true while the current awake-session was started by us (wake_desk);
+  # suppresses the auto-refresh so it cannot retrigger itself forever.
+  - id: self_wake
+    type: bool
+    initial_value: 'false'
+
+uart:
+  - id: desk_uart
+    baud_rate: 9600
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    debug:
+      direction: RX
+      after:
+        delimiter: [0x9D]
+      sequence:
+        - lambda: |-
+            if (bytes.size() == 6 && bytes[1] == 0x04 && bytes[2] == 0x11) {
+              id(last_hb) = millis();  // heartbeat: track silently, don't log
+              return;
+            }
+            UARTDebug::log_hex(direction, bytes, ' ');
+
+# Heartbeat watchdog: when an awake-session ends (>3s silence) that we didn't
+# start, the desk was moved via the physical panel -> refresh the height once.
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          if (id(last_hb) != 0 && (millis() - id(last_hb)) > 3000) {
+            id(last_hb) = 0;
+            if (id(self_wake)) {
+              id(self_wake) = false;
+            } else {
+              id(refresh_height).execute();
+            }
+          }
+
+sensor:
+  - platform: loctekmotion_desk_height
+    uart_id: desk_uart
+    name: "Desk Height"
+    id: desk_height
+
+switch:
+  - platform: gpio
+    name: "Screen Wake"
+    id: screen_wake
+    pin: ${screen_pin}
+    restore_mode: ALWAYS_OFF
+
+script:
+  - id: wake_desk
+    mode: restart
+    then:
+      - globals.set:
+          id: self_wake
+          value: 'true'
+      - switch.turn_on: screen_wake
+      - delay: 15s
+      - switch.turn_off: screen_wake
+  - id: refresh_height
+    mode: single
+    then:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x00, 0x00, 0x6C, 0xA1, 0x9D]
+  # The box travels to presets on its own without reporting. Poll it once per
+  # second (Wake Up frame = "no keys pressed", does not affect motion) so the
+  # height tracks during travel and ends correct. Each iteration restarts
+  # wake_desk so the wake line stays high throughout.
+  - id: poll_height_burst
+    mode: restart
+    then:
+      - repeat:
+          count: 25
+          then:
+            - script.execute: wake_desk
+            - uart.write: [0x9B, 0x06, 0x02, 0x00, 0x00, 0x6C, 0xA1, 0x9D]
+            - delay: 1s
+
+button:
+  - platform: template
+    name: "Desk Up"
+    icon: mdi:arrow-up-bold
+    on_press:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x01, 0x00, 0xFC, 0xA0, 0x9D]
+  - platform: template
+    name: "Desk Down"
+    icon: mdi:arrow-down-bold
+    on_press:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x02, 0x00, 0x0C, 0xA0, 0x9D]
+  - platform: template
+    name: "Desk Preset 1"
+    icon: mdi:numeric-1-box
+    on_press:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x04, 0x00, 0xAC, 0xA3, 0x9D]
+      - script.execute: poll_height_burst
+  - platform: template
+    name: "Desk Preset 2"
+    icon: mdi:numeric-2-box
+    on_press:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x08, 0x00, 0xAC, 0xA6, 0x9D]
+      - script.execute: poll_height_burst
+  - platform: template
+    name: "Desk Preset 3"
+    icon: mdi:numeric-3-box
+    on_press:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x10, 0x00, 0xAC, 0xAC, 0x9D]
+      - script.execute: poll_height_burst
+  - platform: template
+    name: "Desk M"
+    icon: mdi:alpha-m-box
+    on_press:
+      - script.execute: wake_desk
+      - delay: 1s
+      - uart.write: [0x9B, 0x06, 0x02, 0x20, 0x00, 0xAC, 0xB8, 0x9D]
+  - platform: template
+    name: "Refresh Height"
+    icon: mdi:refresh
+    on_press:
+      - script.execute: refresh_height

--- a/packages/flexispot-e1l-esp32.yaml
+++ b/packages/flexispot-e1l-esp32.yaml
@@ -16,7 +16,9 @@
 #   - The box only reports height in response to a command -> preset buttons
 #     poll with Wake Up frames during the autonomous travel.
 #   - A ~5 Hz heartbeat (9b 04 11) runs while the box is awake -> used to
-#     detect adjustments made on the physical panel and re-poll the height.
+#     detect adjustments made on the physical panel; polling during such a
+#     session gives live height tracking of panel-driven moves (wakefulness
+#     is global, and the polls don't interfere with held panel buttons).
 
 substitutions:
   device_name: flexispot-desk
@@ -88,19 +90,19 @@ uart:
             }
             UARTDebug::log_hex(direction, bytes, ' ');
 
-# Heartbeat watchdog: when an awake-session ends (>3s silence) that we didn't
-# start, the desk was moved via the physical panel -> refresh the height once.
+# Heartbeat watchdog: an awake-session we didn't start = the physical panel
+# is in use -> start live_poll so the height tracks the move live. Session
+# end (>3s silence) just clears state.
 interval:
   - interval: 1s
     then:
       - lambda: |-
+          if (id(last_hb) != 0 && !id(self_wake) && !id(live_poll).is_running()) {
+            id(live_poll).execute();
+          }
           if (id(last_hb) != 0 && (millis() - id(last_hb)) > 3000) {
             id(last_hb) = 0;
-            if (id(self_wake)) {
-              id(self_wake) = false;
-            } else {
-              id(refresh_height).execute();
-            }
+            id(self_wake) = false;
           }
 
 sensor:
@@ -132,6 +134,18 @@ script:
       - script.execute: wake_desk
       - delay: 1s
       - uart.write: [0x9B, 0x06, 0x02, 0x00, 0x00, 0x6C, 0xA1, 0x9D]
+  # Live tracking of panel-initiated sessions: poll with the harmless
+  # "no keys pressed" Wake Up frame while the foreign session's heartbeat is
+  # alive (no need to raise PIN 20 — the panel already woke the box).
+  - id: live_poll
+    mode: single
+    then:
+      - while:
+          condition:
+            lambda: 'return id(last_hb) != 0;'
+          then:
+            - uart.write: [0x9B, 0x06, 0x02, 0x00, 0x00, 0x6C, 0xA1, 0x9D]
+            - delay: 1s
   # The box travels to presets on its own without reporting. Poll it once per
   # second (Wake Up frame = "no keys pressed", does not affect motion) so the
   # height tracks during travel and ends correct. Each iteration restarts


### PR DESCRIPTION
Documents the Flexispot E1L (L-shaped, 2 motors, control box CB38M2J(IB)-1 — same as the E7, unmarked touch control panel). Findings from empirically sniffing the control box's second RJ45 port with an ESP32.

**Summary of findings** (full details in the new README section):

- Pinout is identical to HS13B-1, and the standard command set works.
- The two RJ45 jacks are **not parallel taps** — the accessory port never sees the control panel's traffic, only frames the control box itself sends.
- The box **only reports height in response to a received command** (including the Wake Up frame) — never during autonomous preset travel. The included package polls with Wake Up frames during preset moves to track the height.
- Commands are only accepted after PIN 20 has been HIGH for ~1 second (mirrors the physical panel, where the first key press wakes and the second acts).
- While awake the box streams a ~5 Hz heartbeat (`9b 04 11 7c c3 9d`); a heartbeat session your controller did not initiate = the desk was adjusted on the physical panel, useful as a re-poll trigger.
- Checksum verified as **CRC16-Modbus** over length..payload, transmitted high byte first — matches all documented command checksums and allows constructing arbitrary frames.

**Changes:**
- README: new "Flexispot E1L (unmarked touch panel)" section + entry in the supported panels table
- `packages/flexispot-e1l-esp32.yaml`: complete tested ESPHome package handling the quirks above (auto-wake before commands, preset travel polling, heartbeat watchdog)

Everything was verified on a live E1L (commands, presets, height decoding, keypad-move detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)